### PR TITLE
build: Manually link `ispc_texcomp_astc` to prevent bogus `cargo:rerun-if-changed` lines causing full recompilation 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,41 +1,16 @@
 name: CI
 
-# Allows you to run this workflow manually from the Actions tab
 on: [push, pull_request]
 
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build-linux:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-        # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access igitt
-      - uses: actions/checkout@v2
-
-      - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --all-targets
-
-  build-macos: 
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --all-targets
-
-  build-windows: 
-    runs-on: windows-latest
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/generate-binaries.yaml
+++ b/.github/workflows/generate-binaries.yaml
@@ -1,22 +1,14 @@
 name: Generate Linux and macOS binaries
 
-# Allows you to run this workflow manually from the Actions tab
 on: [workflow_dispatch]
 
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build-linux:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-        # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access igitt
       - uses: actions/checkout@v2
 
-      # Runs a single command using the runners shell
       - name: Prepare Environment
 
         run: |
@@ -24,37 +16,37 @@ jobs:
           curl -L https://github.com/ispc/ispc/releases/download/v1.17.0/ispc-v1.17.0-linux.tar.gz | tar xzv --strip-components=2 ispc-v1.17.0-linux/bin/ispc
 
       - name: Build binaries
-        
-        run: | 
+
+        run: |
           PATH=$PATH:$PWD
           cargo build --features=ispc
 
       - uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: kernel.rs
           path: src/ispc/kernel.rs
 
       - uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: kernel_astc.rs
           path: src/ispc/kernel_astc.rs
 
       - uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: libkernelx86_64-unknown-linux-gnu.a
           path: src/ispc/libkernelx86_64-unknown-linux-gnu.a
 
       - uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: libkernel_astcx86_64-unknown-linux-gnu.a
           path: src/ispc/libkernel_astcx86_64-unknown-linux-gnu.a
 
       - uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: libispc_texcomp_astcx86_64-unknown-linux-gnu.a
           path: src/ispc/libispc_texcomp_astcx86_64-unknown-linux-gnu.a
 
-  build-macos: 
+  build-macos:
     runs-on: macos-latest
 
     steps:
@@ -65,26 +57,25 @@ jobs:
           git submodule update --init
           curl -L https://github.com/ispc/ispc/releases/download/v1.17.0/ispc-v1.17.0-macOS.tar.gz | tar xzv --strip-components=2 ispc-v1.17.0-macOS/bin/ispc
 
-      - name: Build binaries        
-        run: | 
+      - name: Build binaries
+        run: |
           PATH=$PATH:$PWD
           cargo build --features=ispc
 
       - uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: libkernelx86_64-apple-darwin.a
           path: src/ispc/libkernelx86_64-apple-darwin.a
 
       - uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: libkernel_astcx86_64-apple-darwin.a
           path: src/ispc/libkernel_astcx86_64-apple-darwin.a
 
       - uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: libispc_texcomp_astcx86_64-apple-darwin.a
           path: src/ispc/libispc_texcomp_astcx86_64-apple-darwin.a
-
       # curl -L  https://github.com/ispc/ispc/releases/download/v1.17.0/ispc-v1.17.0-linux.tar.gz
       # tar -xf ispc_linux.tar.gz -C ispc/
       # Runs a set of commands using the runners shell

--- a/.github/workflows/generate-binaries.yaml
+++ b/.github/workflows/generate-binaries.yaml
@@ -24,28 +24,11 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: kernel.rs
-          path: src/ispc/kernel.rs
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: kernel_astc.rs
-          path: src/ispc/kernel_astc.rs
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libkernelx86_64-unknown-linux-gnu.a
-          path: src/ispc/libkernelx86_64-unknown-linux-gnu.a
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libkernel_astcx86_64-unknown-linux-gnu.a
-          path: src/ispc/libkernel_astcx86_64-unknown-linux-gnu.a
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libispc_texcomp_astcx86_64-unknown-linux-gnu.a
-          path: src/ispc/libispc_texcomp_astcx86_64-unknown-linux-gnu.a
+          name: Ubuntu ISPC kernels
+          path: |
+            src/ispc/kernel{,_astc}.rs
+            src/ispc/libkernel{,_astc}x86_64-unknown-linux-gnu.a
+            src/ispc/libispc_texcomp_astcx86_64-unknown-linux-gnu.a
 
   build-macos:
     runs-on: macos-latest
@@ -66,22 +49,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: libkernelx86_64-apple-darwin.a
-          path: src/ispc/libkernelx86_64-apple-darwin.a
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libkernel_astcx86_64-apple-darwin.a
-          path: src/ispc/libkernel_astcx86_64-apple-darwin.a
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libispc_texcomp_astcx86_64-apple-darwin.a
-          path: src/ispc/libispc_texcomp_astcx86_64-apple-darwin.a
-      # curl -L  https://github.com/ispc/ispc/releases/download/v1.17.0/ispc-v1.17.0-linux.tar.gz
-      # tar -xf ispc_linux.tar.gz -C ispc/
-      # Runs a set of commands using the runners shell
-      #- name: Run a multi-line script
-      #  run: |
-      #    echo Add other actions to build,
-      #    echo test, and deploy your project.
+          name: MacOS ISPC kernels
+          path: |
+            src/ispc/libkernel{,_astc}x86_64-apple-darwin.a
+            src/ispc/libispc_texcomp_astcx86_64-apple-darwin.a

--- a/.github/workflows/generate-binaries.yaml
+++ b/.github/workflows/generate-binaries.yaml
@@ -7,12 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Prepare Environment
 
         run: |
-          git submodule update --init
           curl -L https://github.com/ispc/ispc/releases/download/v1.17.0/ispc-v1.17.0-linux.tar.gz | tar xzv --strip-components=2 ispc-v1.17.0-linux/bin/ispc
 
       - name: Build binaries
@@ -50,11 +51,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Prepare Environment
         run: |
-          git submodule update --init
           curl -L https://github.com/ispc/ispc/releases/download/v1.17.0/ispc-v1.17.0-macOS.tar.gz | tar xzv --strip-components=2 ispc-v1.17.0-macOS/bin/ispc
 
       - name: Build binaries

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
 Cargo.lock
-/src/ispc/*

--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,17 @@
 extern crate ispc_rt;
 
 #[cfg(feature = "ispc")]
-
 /*
 ISPC project file builds the kernels as such:
 <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ispc -O2 "%(Filename).ispc" -o "$(TargetDir)%(Filename).obj" -h "$(ProjectDir)%(Filename)_ispc.h" --target=sse2,sse4,avx,avx2 --opt=fast-math</Command>
 <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(TargetDir)%(Filename).obj;$(TargetDir)%(Filename)_sse2.obj;$(TargetDir)%(Filename)_sse4.obj;$(TargetDir)%(Filename)_avx.obj;$(TargetDir)%(Filename)_avx2.obj;</Outputs>
 */
-
 #[cfg(feature = "ispc")]
 use ispc_compile::{TargetISA, TargetOS};
 
 #[cfg(feature = "ispc")]
 #[cfg(target_os = "linux")]
-fn get_target_os() -> TargetOS  {
+fn get_target_os() -> TargetOS {
     TargetOS::Linux
 }
 
@@ -31,7 +29,6 @@ fn get_target_os() -> TargetOS {
 
 #[cfg(feature = "ispc")]
 fn compile_kernel() {
-
     ispc_compile::Config::new()
         .file("vendor/ispc_texcomp/kernel.ispc")
         .opt_level(2)
@@ -73,8 +70,10 @@ fn compile_kernel() {
         .file("vendor/ispc_texcomp/ispc_texcomp_astc.cpp")
         .out_dir("src/ispc")
         // format the output name such that ispc_rt::PackagedModule can just pick it up easily
-        .compile(&format!("ispc_texcomp_astc{}", std::env::var("TARGET").unwrap()));
-
+        .compile(&format!(
+            "ispc_texcomp_astc{}",
+            std::env::var("TARGET").unwrap()
+        ));
 }
 
 #[cfg(not(feature = "ispc"))]

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -37,20 +37,18 @@ fn main() {
     let alpha_mode = AlphaMode::Opaque;
     let depth = 1;
 
-    let mut dds = Dds::new_dxgi(
-        NewDxgiParams {
-            height,
-            width,
-            depth: Some(depth),
-            format: DxgiFormat::BC7_UNorm,
-            mipmap_levels: Some(mip_count),
-            array_layers: Some(array_layers),
-            caps2: Some(caps2),
-            is_cubemap,
-            resource_dimension,
-            alpha_mode,
-        }
-    )
+    let mut dds = Dds::new_dxgi(NewDxgiParams {
+        height,
+        width,
+        depth: Some(depth),
+        format: DxgiFormat::BC7_UNorm,
+        mipmap_levels: Some(mip_count),
+        array_layers: Some(array_layers),
+        caps2: Some(caps2),
+        is_cubemap,
+        resource_dimension,
+        alpha_mode,
+    })
     .unwrap();
 
     let surface = intel_tex_2::RgbaSurface {


### PR DESCRIPTION
This was added in dcf62dc ("Prepare for release") yet is not an ISPC module (there's no `ispc_module!(ispc_texcomp_astc)`) nor were the Rust bindgen bindings added for this library.  It results in `build.rs` emitting the following line:

    cargo:rerun-if-changed=src/ispc/ispc_texcomp_astc.rs

This file does not exist, causing `cargo` to continuously rebuild this crate and everything that depends on it (~10 crates on our side).  We could have removed this library and all logic around it since the only symbol needed from it resides in a codepath that's commented out, but MSVC - unlike any other compiler - is unable to deadstrip it and tries to look for the symbol regardless, resulting in obvious [linker errors].

[linker errors]: https://github.com/Traverse-Research/intel-tex-rs-2/runs/5829771452?check_suite_focus=true

---

Furthermore, a bunch of things I noticed while wrapping my head around this repo:

-  We still have https://github.com/Traverse-Research/intel-tex-rs which is set up as a fork of the original repo whereas this repo is a "clean push" of the same commits. IMO we shouldn't have two duplicate repos: I prefer to keep the one that has `forked from gwihlidal/intel-tex-rs` since that gives us a bit more visibility in the network graph - but we'll have to push all these new commits and tags, and rename that one (all fairly trivial).
- Windows binaries are not built in the CI?
- We can probably also build 32-bit and arm32/aarch64 binaries just like https://github.com/Danielmelody/ispc-texcomp-rs/blob/master/.github/workflows/publish.yml.
